### PR TITLE
Add .env file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 .vercel
 
 /theme/renge/
+
+# local env
+.env


### PR DESCRIPTION
I noticed that after I copied the .env.sample the new .env file was showing in the git changes. I assume this shouldn't be the case but could be wrong.