### PR TITLE
Fix mobile nav menu formatting

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,34 +6,57 @@ import {
   ListItem,
   ListIcon,
   List,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
   IconButton,
   useDisclosure,
   Button,
-} from "@chakra-ui/react";
-import { HamburgerIcon, Search2Icon } from "@chakra-ui/icons";
-import { FaEllipsisH } from "react-icons/fa";
-import SearchModal from "./SearchModal";
-import { useHotkeys } from "react-hotkeys-hook";
-import { checkWallet, connectWallet, disconnectWallet, checkWeb3 } from "../lib/web3";
-import { useState } from "react";
-
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerBody,
+  DrawerCloseButton,
+} from '@chakra-ui/react';
+import { HamburgerIcon, Search2Icon } from '@chakra-ui/icons';
+import SearchModal from './SearchModal';
+import { useHotkeys } from 'react-hotkeys-hook';
+import {
+  checkWallet,
+  checkWeb3,
+  connectWallet,
+  disconnectWallet,
+} from '../lib/web3';
+import React, { useState } from 'react';
 import Link from './Link';
 
 export default function Navbar() {
+  const {
+    isOpen: searchModalIsOpen,
+    onOpen: onSearchModalOpen,
+    onClose: onSearchModalClose,
+  } = useDisclosure();
+  const {
+    isOpen: mobileMenuIsOpen,
+    onOpen: onMobileMenuOpen,
+    onClose: onMobileMenuClose,
+  } = useDisclosure();
+  useHotkeys('/', (e) => {
+    e.preventDefault();
+    onSearchModalOpen();
+  });
   return (
     <Box as="header" width="100%" color="white" overflowY="visible">
-      <Flex className="header-wrap" minH="unset" marginTop={{ sm: "30px" }} marginBottom={{ sm: "60px" }}>
-        <Box className="header-logo" position={{ sm: "static", lg: "absolute"}}>
+      <SearchModal isOpen={searchModalIsOpen} onClose={onSearchModalClose} />
+      <Flex
+        className="header-wrap"
+        minH="unset"
+        marginTop={{ sm: '30px' }}
+        marginBottom={{ sm: '60px' }}>
+        <Box
+          className="header-logo"
+          position={{ sm: 'static', lg: 'absolute' }}>
           <Heading as="h1" margin="0" lineHeight="0">
-            <Link href="/"
-              style={{ boxShadow: "none" }}
-              display="inline-block">
+            <Link href="/" style={{ boxShadow: 'none' }} display="inline-block">
               <Image
-                style={{ boxShadow: "none" }}
+                style={{ boxShadow: 'none' }}
                 src="/images/bankless-logo.png"
                 alt="Bankless"
                 maxW="300px"
@@ -44,45 +67,46 @@ export default function Navbar() {
         </Box>
         <Box className="header-nav">
           <Flex as="nav" id="mobile-nav">
-            <Menu>
-              <ConnectionButton />
-              <MenuButton
-                as={IconButton}
-                aria-label="site navigation menu"
-                icon={<HamburgerIcon />}
-                fontSize="32px"
-                backgroundColor="transparent"
-                sx={{
-                  _hover: { background: "transparent" },
-                  _active: { background: "transparent" },
-                }}
-              />
-              <MenuList
-                zIndex={1}
-                borderRadius={0}
-                background="var(--bg-nav)"
-                border="none"
-                fontSize="14px"
-                width="200px"
-              >
-                <MenuItem justifyContent="flex-end">
-                  <Link href="/">Home</Link>
-                </MenuItem>
-                <MenuItem justifyContent="flex-end">
-                  <Link href="/guilds">Guilds</Link>
-                </MenuItem>
-                <MenuItem justifyContent="flex-end">
-                  <Link href="/contribute">Contribute</Link>
-                </MenuItem>
-                {/*<MenuItem justifyContent="flex-end">
-                  <Link href="/signup">Register for Free</Link>
-                </MenuItem>
-                <MenuItem justifyContent="flex-end">
-                  <Link href="/signin">Sign In</Link>
-              </MenuItem>*/}
-                <SearchButtonMobile />
-              </MenuList>
-            </Menu>
+            <IconButton
+              aria-label="site navigation menu"
+              variant="unstyled"
+              icon={<HamburgerIcon />}
+              fontSize="32px"
+              onClick={onMobileMenuOpen}
+              _focus={{
+                outline: 'none',
+              }}
+            />
+            <Drawer
+              isOpen={mobileMenuIsOpen}
+              placement="right"
+              onClose={onMobileMenuClose}>
+              <DrawerOverlay />
+              <DrawerContent paddingTop="4" background="var(--bg-nav)">
+                <DrawerCloseButton size="lg" />
+
+                <DrawerBody paddingTop="4">
+                  <List spacing="2" fontWeight="bold" fontFamily="spartan">
+                    <ListItem>
+                      <Link href="/">Home</Link>
+                    </ListItem>
+                    <ListItem>
+                      <Link href="/guilds">Guilds</Link>
+                    </ListItem>
+                    <ListItem>
+                      <Link href="/contribute">Contribute</Link>
+                    </ListItem>
+                    <ListItem display="flex" onClick={onSearchModalOpen}>
+                      <Box marginRight="4">Search</Box>
+                      <ListIcon as={Search2Icon} color="white" />
+                    </ListItem>
+                    <ListItem>
+                      <ConnectionButton size="sm" />
+                    </ListItem>
+                  </List>
+                </DrawerBody>
+              </DrawerContent>
+            </Drawer>
           </Flex>
           <Flex as="nav">
             <List>
@@ -97,15 +121,14 @@ export default function Navbar() {
               </ListItem>
             </List>
             <List>
-              {/*<ListItem className="signup global-button">
-                    <Link href="/signup">Register for Free!</Link>
-                </ListItem>
-                <ListItem className="signin">
-                    <Link href="/signin">Sign In</Link>
-                    </ListItem>*/}
-              <ConnectionButton />
+              <ConnectionButton fontSize="12px" marginRight="18px" />
               <ListItem>
-                <SearchButton />
+                <Button
+                  variant="unstyled"
+                  _focus={{ outline: 'none' }}
+                  onClick={onSearchModalOpen}>
+                  <ListIcon as={Search2Icon} color="white" />
+                </Button>
               </ListItem>
             </List>
           </Flex>
@@ -115,86 +138,46 @@ export default function Navbar() {
   );
 }
 
-function SearchButton() {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  useHotkeys("/", (e) => {
-    e.preventDefault();
-    onOpen();
-  });
-  return (
-    <>
-      <Button variant="unstyled" _focus={{ outline: "none" }} onClick={onOpen}>
-        <ListIcon as={Search2Icon} color="white" />
-      </Button>
-      <SearchModal isOpen={isOpen} onClose={onClose} />
-    </>
-  );
-}
-
-function SearchButtonMobile() {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  useHotkeys("/", (e) => {
-    e.preventDefault();
-    onOpen();
-  });
-  return (
-    <>
-
-      <MenuItem
-        justifyContent="flex-end"
-        color="var(--bg-nav)"
-        background="var(--color-details)"
-        onClick={onOpen}
-      >
-        Search
-        <Button variant="unstyled" _focus={{ outline: "none" }} >
-          <ListIcon as={Search2Icon} color="white" />
-        </Button>
-        <SearchModal isOpen={isOpen} onClose={onClose} />
-      </MenuItem>
-    </>
-  );
-}
-
-function ConnectionButton() {
-  const [wallet, setWallet] = useState("");
+function ConnectionButton({ ...props }) {
+  const [wallet, setWallet] = useState('');
   // Defining button actions
   async function connectionIntent() {
-    console.log('Connecting wallet...')
-    let web3Check = await checkWeb3()
-    console.log('Web3 exists?', web3Check)
+    console.log('Connecting wallet...');
+    let web3Check = await checkWeb3();
+    console.log('Web3 exists?', web3Check);
     if (web3Check) {
-      let connected = await connectWallet()
-      console.log(connected)
+      let connected = await connectWallet();
+      console.log(connected);
       if (connected !== false && connected.indexOf('0x') === 0) {
-        setWallet(connected)
+        setWallet(connected);
       }
     } else {
-      alert('Please browse website with Metamask Mobile!')
+      alert('Please browse website with Metamask Mobile!');
     }
   }
   async function signoutIntent() {
-    console.log('Disconnecting wallet...')
-    await disconnectWallet()
-    setWallet("")
+    await disconnectWallet();
+    setWallet('');
   }
   // Check if wallet is connected
-  checkWallet().then(check => {
+  checkWallet().then((check) => {
     if (check !== false) {
-      setWallet(check)
+      setWallet(check);
     }
-  })
+  });
+  let text, onClick;
+
   if (wallet.length === 0) {
-    return (
-      <ListItem className="signup global-button connection-button" onClick={connectionIntent}>
-        <Link href="#">Connect Wallet</Link>
-      </ListItem>
-    )
+    text = 'Connect Wallet';
+    onClick = connectionIntent;
   } else {
-    return (
-      <ListItem className="signup global-button connection-button" onClick={signoutIntent}>
-        <Link href="#">Sign out from {wallet.substr(0, 3)}..{wallet.substr(-3)}</Link>
-      </ListItem>
-    )
+    text = `Sign out from ${wallet.substr(0, 3)}..${wallet.substr(-3)}`;
+    onClick = signoutIntent;
   }
+
+  return (
+    <Button onClick={onClick} {...props}>
+      {text}
+    </Button>
+  );
 }

--- a/components/NextPrevPost.tsx
+++ b/components/NextPrevPost.tsx
@@ -1,167 +1,147 @@
-import { chakra, Flex, Image, Link, Heading } from "@chakra-ui/react"
-import { PostOrPage } from "../lib/types/ghost-types";
+import { chakra, Flex, Image, Link, Heading } from '@chakra-ui/react';
+import { PostOrPage } from '../lib/types/ghost-types';
 
 type NextPrevSectionProps = {
-    newerPost?: {
-        feature_image: string,
-        feature_image_alt: string,
-        title: string,
-        slug: string
-    } | null,
-    olderPost?: {
-        feature_image: string,
-        feature_image_alt: string,
-        title: string,
-        slug: string
-    } | null
+  newerPost?: {
+    feature_image: string;
+    feature_image_alt: string;
+    title: string;
+    slug: string;
+  } | null;
+  olderPost?: {
+    feature_image: string;
+    feature_image_alt: string;
+    title: string;
+    slug: string;
+  } | null;
 };
 
 const NextPrevSection = ({ newerPost, olderPost }: NextPrevSectionProps) => {
-
-    return (
+  return (
+    <Flex
+      as="aside"
+      width="100%"
+      margin="10vh auto 16vh"
+      borderTop="var(--border) var(--color-three)"
+      borderBottom="var(--border) var(--color-three)"
+      height="200px">
+      {newerPost && (
         <Flex
-            as="aside"
-            width="100%"
-            margin="10vh auto 16vh"
-            borderTop="var(--border) var(--color-three)"
-            borderBottom="var(--border) var(--color-three)"
-            height="200px"
-        >
-            {
-                newerPost &&
-                <Flex
-                    as="section"
-                    boxSizing="border-box"
-                    margin="40px 0"
-                    flex="1 0 50%"
-                    paddingRight="20px"
-                >
-                    <Link
-                        href={newerPost.slug}
-                        marginRight="20px"
-                        marginLeft="10px"
-                        position="relative"
-                        transform="translateY(5px)"
-                        flex="0 0 120px"
-                        sx={{
-                            _after: {
-                                position: "absolute",
-                                zIndex: "-1",
-                                top: "-10px",
-                                right: "10px",
-                                bottom: "10px",
-                                left: "-10px",
-                                content: "''",
-                                pointerEvents: "none",
-                                background: "#ff4a97"
-                            }
-                        }}
-                    >
-                        <Image
-                            src={newerPost.feature_image}
-                            alt={newerPost.feature_image_alt}
-                            position="absolute"
-                            top={0}
-                            right={0}
-                            bottom={0}
-                            left={0}
-                            width="120px"
-                            minHeight="120px"
-                            objectFit="cover"
-
-                        />
-                    </Link>
-                    <chakra.div maxW="400px" alignSelf="center">
-                        <chakra.small
-                            fontFamily="four"
-                            fontSize="13px"
-                            fontWeight="500"
-                        >
-                            Newer post
-                        </chakra.small>
-                        <Heading
-                            as="h3"
-                            display="block"
-                            marginTop="10px"
-                            marginBottom="0"
-                            fontSize="18px"
-                        >
-                            <Link
-                                href={newerPost.slug}
-                                className="global-underline"
-                            >
-                                {newerPost.title}
-                            </Link>
-                        </Heading>
-                    </chakra.div>
-                </Flex>
-            }
-            {
-                olderPost &&
-                <Flex
-                    as="section"
-                    boxSizing="border-box"
-                    margin="40px 0"
-                    flex="1 0 50%"
-                    justifyContent="flex-end"
-                    paddingLeft="20px"
-                >
-                    <chakra.div maxW="400px" alignSelf="center">
-                        <chakra.small
-                            fontFamily="four"
-                            fontSize="13px"
-                            fontWeight="500"
-                        >Older post</chakra.small>
-                        <Heading
-                            as="h3"
-                            display="block"
-                            marginTop="10px"
-                            marginBottom="0"
-                            fontSize="18px"
-                        >
-                            <Link href={olderPost.slug} className="global-underline">
-                                {olderPost.title}
-                            </Link>
-                        </Heading>
-                    </chakra.div>
-                    <Link
-                        href={olderPost.slug}
-                        marginRight="20px"
-                        marginLeft="10px"
-                        position="relative"
-                        transform="translateY(5px)"
-                        flex="0 0 120px"
-                        sx={{
-                            _after: {
-                                position: "absolute",
-                                zIndex: "-1",
-                                top: "-10px",
-                                right: "10px",
-                                bottom: "10px",
-                                left: "-10px",
-                                content: "''",
-                                pointerEvents: "none",
-                                background: "#fed672"
-                            }
-                        }}
-                    >
-                        <Image
-                            src={olderPost.feature_image}
-                            alt={olderPost.feature_image_alt}
-                            position="absolute"
-                            top={0}
-                            right={0}
-                            bottom={0}
-                            left={0}
-                            width="120px"
-                            minHeight="120px"
-                            objectFit="cover"
-                        />
-                    </Link>
-                </Flex>
-            }
+          as="section"
+          boxSizing="border-box"
+          margin="40px 0"
+          flex="1 0 50%"
+          paddingRight="20px">
+          <Link
+            href={newerPost.slug}
+            marginRight="20px"
+            marginLeft="10px"
+            position="relative"
+            transform="translateY(5px)"
+            flex="0 0 120px"
+            sx={{
+              _after: {
+                position: 'absolute',
+                zIndex: '-1',
+                top: '-10px',
+                right: '10px',
+                bottom: '10px',
+                left: '-10px',
+                content: "''",
+                pointerEvents: 'none',
+                background: '#ff4a97',
+              },
+            }}>
+            <Image
+              src={newerPost.feature_image}
+              alt={newerPost.feature_image_alt}
+              position="absolute"
+              top={0}
+              right={0}
+              bottom={0}
+              left={0}
+              width="120px"
+              minHeight="120px"
+              objectFit="cover"
+            />
+          </Link>
+          <chakra.div maxW="400px" alignSelf="center">
+            <chakra.small fontFamily="mono" fontSize="13px" fontWeight="500">
+              Newer post
+            </chakra.small>
+            <Heading
+              as="h3"
+              display="block"
+              marginTop="10px"
+              marginBottom="0"
+              fontSize="18px">
+              <Link href={newerPost.slug} className="global-underline">
+                {newerPost.title}
+              </Link>
+            </Heading>
+          </chakra.div>
         </Flex>
-    );
+      )}
+      {olderPost && (
+        <Flex
+          as="section"
+          boxSizing="border-box"
+          margin="40px 0"
+          flex="1 0 50%"
+          justifyContent="flex-end"
+          paddingLeft="20px">
+          <chakra.div maxW="400px" alignSelf="center">
+            <chakra.small fontFamily="mono" fontSize="13px" fontWeight="500">
+              Older post
+            </chakra.small>
+            <Heading
+              as="h3"
+              display="block"
+              marginTop="10px"
+              marginBottom="0"
+              fontSize="18px">
+              <Link href={olderPost.slug} className="global-underline">
+                {olderPost.title}
+              </Link>
+            </Heading>
+          </chakra.div>
+          <Link
+            href={olderPost.slug}
+            marginRight="20px"
+            marginLeft="10px"
+            position="relative"
+            transform="translateY(5px)"
+            flex="0 0 120px"
+            sx={{
+              _after: {
+                position: 'absolute',
+                zIndex: '-1',
+                top: '-10px',
+                right: '10px',
+                bottom: '10px',
+                left: '-10px',
+                content: "''",
+                pointerEvents: 'none',
+                background: '#fed672',
+              },
+            }}>
+            <Image
+              src={olderPost.feature_image}
+              alt={olderPost.feature_image_alt}
+              position="absolute"
+              top={0}
+              right={0}
+              bottom={0}
+              left={0}
+              width="120px"
+              minHeight="120px"
+              objectFit="cover"
+            />
+          </Link>
+        </Flex>
+      )}
+    </Flex>
+  );
 };
 
 export default NextPrevSection;

--- a/components/SearchModal.tsx
+++ b/components/SearchModal.tsx
@@ -75,7 +75,9 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
   }
 
   function handleDownKey() {
-    setActiveIndex((prevActiveIndex) => Math.min(prevActiveIndex + 1, filteredResults.length - 1));
+    setActiveIndex((prevActiveIndex) =>
+      Math.min(prevActiveIndex + 1, filteredResults.length - 1),
+    );
   }
 
   function handleEnterKey() {
@@ -117,7 +119,11 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
       return '';
     }
     const date = new Date(d);
-    return date.toLocaleString('en', { year: 'numeric', month: 'long', day: 'numeric' });
+    return date.toLocaleString('en', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
   }
 
   return (
@@ -128,8 +134,8 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
           <Input
             variant="unstyled"
             placeholder="Type your keywords"
-            fontFamily="two"
-            fontSize="30px"
+            fontFamily="spartan"
+            fontSize={{ sm: '15px', md: '30px' }}
             display="block"
             color="white"
             height="auto"
@@ -154,22 +160,22 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
                   borderColor="var(--color-three)"
                   borderStyle="dashed"
                 />
-              }
-            >
+              }>
               {filteredResults.map((post, index) => (
                 <LinkBox
                   key={post.id}
                   padding="20px"
-                  background={activeIndex === index ? 'rgba(0,0,0, 0.3)' : 'transparent'}
-                  onMouseEnter={() => setActiveIndex(index)}
-                >
+                  background={
+                    activeIndex === index ? 'rgba(0,0,0, 0.3)' : 'transparent'
+                  }
+                  onMouseEnter={() => setActiveIndex(index)}>
                   <NextLink href={post.slug}>
                     <LinkOverlay href={post.slug} />
                   </NextLink>
-                  <Box fontFamily="four" fontSize="small">
+                  <Box fontFamily="mono" fontSize="small">
                     Published - {formatDate(post.published_at || '')}
                   </Box>
-                  <Box fontFamily="two" marginTop="2">
+                  <Box fontFamily="spartan" marginTop="2">
                     {post.title}
                   </Box>
                 </LinkBox>
@@ -184,7 +190,7 @@ export default function SearchModal({ isOpen, onClose }: SearchModalProps) {
 
 const HelpBox = chakra(Box, {
   baseStyle: {
-    fontFamily: 'four',
+    fontFamily: 'mono',
     background: 'red',
     color: 'var(--color-font-two)',
     padding: '8px 20px',

--- a/components/SubArticle.tsx
+++ b/components/SubArticle.tsx
@@ -3,49 +3,62 @@ import { PostOrPage, Tag } from '@tryghost/content-api';
 import Link from './Link';
 
 type SubArticleProps = {
-  post: PostOrPage,
-  index: number
-}
+  post: PostOrPage;
+  index: number;
+};
 
 const SubArticle = ({ post, index }: SubArticleProps) => {
   return (
     <Box
       as="article"
       className={`item is-image post ${index % 2 !== 0 ? 'is-even' : 'is-odd'}`}
-      maxW="50%"
-    >
+      maxW="50%">
       <Flex className="item-container">
         <Box className="item-content">
-          <Link style={{ boxShadow: "none" }} className="item-image global-image" href={`/${post.slug}`}>
+          <Link
+            style={{ boxShadow: 'none' }}
+            className="item-image global-image"
+            href={`/${post.slug}`}>
             <Image
               loading="lazy"
               src={post.feature_image!}
-              alt="placeholder image" />
+              alt="placeholder image"
+            />
           </Link>
           <Heading as="h2" className="item-title">
-            <Link style={{ boxShadow: "none" }}  className="global-underline" href={`/${post.slug}`} textDecoration="none">{post.title}</Link>
+            <Link
+              style={{ boxShadow: 'none' }}
+              className="global-underline"
+              href={`/${post.slug}`}
+              textDecoration="none">
+              {post.title}
+            </Link>
           </Heading>
-          <Text className="global-meta">
-            {post.primary_author!.name}
-          </Text>
-          {post.excerpt && <Text className="item-excerpt" fontFamily="one" fontWeight="500" fontSize="13px">
-            {post.excerpt}
-          </Text>
-          }
+          <Text className="global-meta">{post.primary_author!.name}</Text>
+          {post.excerpt && (
+            <Text
+              className="item-excerpt"
+              fontFamily="spartan"
+              fontWeight="500"
+              fontSize="13px">
+              {post.excerpt}
+            </Text>
+          )}
           <Box className="global-tags">
             {post.tags!.map((tag: Tag) => (
               <Link
                 key={tag.id}
                 textTransform="lowercase"
                 textDecoration="none"
-                href={`tag/${tag.slug}`}
-              >#{tag.name}</Link>
+                href={`tag/${tag.slug}`}>
+                #{tag.name}
+              </Link>
             ))}
           </Box>
         </Box>
       </Flex>
     </Box>
-  )
-}
+  );
+};
 
-export default SubArticle
+export default SubArticle;

--- a/components/SubscribeSection.tsx
+++ b/components/SubscribeSection.tsx
@@ -15,7 +15,7 @@ export const ALERT_MESSAGES: AlertMessages = {
 
 const AlertBox = chakra(Box, {
   baseStyle: {
-    fontFamily: 'four',
+    fontFamily: 'mono',
     fontSize: '12px',
     lineHeight: 1.1,
     position: 'absolute',
@@ -78,7 +78,7 @@ export default function SubscribeSection() {
             onChange={handleChange}
             isRequired
           />
-          <Button className="global-button" type="submit">
+          <Button height="auto" type="submit">
             Subscribe
           </Button>
           <AlertBox>{ALERT_MESSAGES[message]}</AlertBox>

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -1,0 +1,14 @@
+import { Colors } from '@chakra-ui/react';
+
+const colors: Colors = {
+  red: {
+    '500': '#ff1a1a',
+  },
+  steel: {
+    '100': '#182029',
+    '400': '#485b73',
+    '900': '#f7f9f9',
+  },
+};
+
+export default colors;

--- a/theme/components/button.ts
+++ b/theme/components/button.ts
@@ -1,25 +1,42 @@
-export default {
-    baseStyle: { },
-    sizes: { },
-    variants: { 
-        "loadMore": {
-            display: "none",
-            width: "50px",
-            height: "50px",
-            padding: "0",
-            cursor: "pointer",
-            transitionTimingFunction: "cubic-bezier(.39,.07,.68,1.7)",
-            transitionDuration: ".25s",
-            transitionProperty: "transform,background-color",
-            border: "10px solid var(--color-details)",
-            borderRadius: "50px",
-            outline: "0",
-            backgroundColor: "var(--color-body)",
-            _hover: {
-                transform: "scale(.6)",
-                backgroundColor: "var(--color-details)"
-            }
-        }
+import { ComponentSingleStyleConfig } from '@chakra-ui/react';
+
+const Button: ComponentSingleStyleConfig = {
+  baseStyle: {},
+  sizes: {},
+  variants: {
+    solid: {
+      fontFamily: 'spartan',
+      cursor: 'pointer',
+      letterSpacing: '1px',
+      borderRadius: 0,
+      color: 'steel.100',
+      bg: 'red.500',
+      _hover: {
+        bg: 'red.600',
+      },
     },
-    defaultProps: { }
-}
+    loadMore: {
+      display: 'none',
+      width: '50px',
+      height: '50px',
+      padding: '0',
+      cursor: 'pointer',
+      transitionTimingFunction: 'cubic-bezier(.39,.07,.68,1.7)',
+      transitionDuration: '.25s',
+      transitionProperty: 'transform,background-color',
+      border: '10px solid var(--color-details)',
+      borderRadius: '50px',
+      outline: '0',
+      backgroundColor: 'var(--color-body)',
+      _hover: {
+        transform: 'scale(.6)',
+        backgroundColor: 'var(--color-details)',
+      },
+    },
+  },
+  defaultProps: {
+    variant: 'solid',
+  },
+};
+
+export default Button;

--- a/theme/components/link.ts
+++ b/theme/components/link.ts
@@ -1,17 +1,19 @@
-export default {
-    baseStyle: { 
-        transitionProperty: null,
-        transitionDuration: null,
-        cursor: "pointer",
-        textDecoration: "none",
-        outline: "2px solid transparent",
-        outlineOffset: "2px",
-        color: "inherit",
-        _hover: {
-            textDecoration: "none"
-        }
+const Link = {
+  baseStyle: {
+    transitionProperty: null,
+    transitionDuration: null,
+    cursor: 'pointer',
+    textDecoration: 'none',
+    outline: '2px solid transparent',
+    outlineOffset: '2px',
+    color: 'inherit',
+    _hover: {
+      textDecoration: 'none',
     },
-    sizes: { },
-    variants: { },
-    defaultProps: { }
-}
+  },
+  sizes: {},
+  variants: {},
+  defaultProps: {},
+};
+
+export default Link;

--- a/theme/components/list.ts
+++ b/theme/components/list.ts
@@ -1,13 +1,10 @@
-export default {
-    parts: [
-        "container",
-        "item",
-        "icon"
-    ],
-    baseStyle: { 
-        display: "inline-block"
-    },
-    sizes: { },
-    variants: { },
-    defaultProps: { }
-}
+const List = {
+  parts: ['container', 'item', 'icon'],
+  baseStyle: {
+    display: 'inline-block',
+  },
+  sizes: {},
+  variants: {},
+  defaultProps: {},
+};
+export default List;

--- a/theme/fonts.ts
+++ b/theme/fonts.ts
@@ -1,6 +1,5 @@
 export default {
-    one: "Spartan",
-    two: "Spartan",
-    three: "Mulish",
-    four: "Source Code Pro"
-}
+  spartan: 'Spartan',
+  mulish: 'Mulish',
+  mono: 'Source Code Pro',
+};

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -1,34 +1,34 @@
 // Charka extendTheme.
-import { extendTheme } from "@chakra-ui/react";
+import { baseStyle, extendTheme } from '@chakra-ui/react';
 
 // Import override modules.
 import breakpoints from './breakpoints';
+import colors from './colors';
 import styles from './styles';
 import fonts from './fonts';
 
 // Import component overrides.
 import Button from './components/button';
-import List from "./components/list";
-import Link from "./components/link";
+import List from './components/list';
+import Link from './components/link';
 import Input from './components/input';
 import Menu from './components/menu';
 import GuildTag from './components/guild-tag';
 
 // Custom app theme overrides.
-
-// TODO: figure out correct typing for override. If any is not added causes VSCode to yell at me.
 const overrides: any = {
-    styles,
-    breakpoints,
-    fonts,
-    components: {
-        Button,
-        List,
-        Link,
-        Input,
-        Menu,
-        GuildTag
-    }
+  colors,
+  styles,
+  breakpoints,
+  fonts,
+  components: {
+    Button,
+    List,
+    Link,
+    Input,
+    Menu,
+    GuildTag,
+  },
 };
 
 export default extendTheme(overrides);

--- a/theme/styles.ts
+++ b/theme/styles.ts
@@ -1,1043 +1,1030 @@
-import { background, flexbox } from "@chakra-ui/react";
+/*
+ TODO: TURN MOST OF THESE STYLES INTO NON-GLOBAL STYLES BY USING COMPONENTS OR STYLE MIXINS
 
+ PLEASE TRY NOT TO ADD ANYTHING TO THIS FILE.
+*/
 export default {
-    global: {
-        ":root": {
-            "--bg-nav": "#242d39",
-            "--accent-color": "#ff1a1a",
-            "--color-body": "#182029",
-            "--color-details": "#ff1a1a",
-            "--color-two": "#f7f9f9",
-            "--color-dots": "#485b73",
-            "--color-three": "#485b73",
-            "--border": "1px dashed",
-            "--font-weight-four-medium": "500",
-            "--color-font-two": "#182029",
-            "--color-announcements": "#fed672"
+  global: {
+    ':root': {
+      '--bg-nav': '#242d39',
+      '--accent-color': '#ff1a1a',
+      '--color-body': '#182029',
+      '--color-details': '#ff1a1a',
+      '--color-two': '#f7f9f9',
+      '--color-dots': '#485b73',
+      '--color-three': '#485b73',
+      '--border': '1px dashed',
+      '--font-weight-four-medium': '500',
+      '--color-font-two': '#182029',
+      '--color-announcements': '#fed672',
+    },
+    '.global-wrap': {
+      height: '100%',
+    },
+    '.global-button': {
+      fontFamily: 'spartan',
+      lineHeight: 1,
+      position: 'relative',
+      zIndex: 0,
+      cursor: 'pointer',
+      letterSpacing: '1px',
+      color: 'var(--color-font-two)',
+      border: 0,
+      outline: 0,
+      _before: {
+        zIndex: -1,
+        background: 'var(--color-details)',
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        left: 0,
+        bottom: 0,
+        content: "''",
+      },
+      _after: {
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        left: 0,
+        bottom: 0,
+        content: "''",
+      },
+    },
+    '.global-content': {
+      base: {
+        display: 'flex',
+        position: 'relative',
+        flexDirection: 'column',
+        paddingRight: '6%',
+        paddingLeft: '6%',
+        height: '100%',
+        maxW: 'unset',
+      },
+      md: {
+        padding: '0 55px',
+      },
+    },
+    '.global-main': {
+      width: '100%',
+      maxW: '1200px',
+      marginLeft: 'auto',
+      marginRight: 'auto',
+    },
+    '.global-underline': {
+      paddingBottom: '.2%',
+      transition: 'background-size .6s ease-out',
+      background:
+        'linear-gradient(var(--accent-color), var(--accent-color)) no-repeat left 123%/0 40%',
+    },
+    '.global-underline:hover': {
+      backgroundSize: '97% 40%',
+    },
+    '.global-special': {
+      base: {
+        paddingTop: '10px',
+        borderTop: '4px solid var(--color-details)',
+        flexGrow: 1,
+        position: 'relative',
+        flexWrap: 'wrap',
+      },
+      sm: {
+        margin: '10vh auto 25px',
+        marginTop: 0,
+      },
+      md: {
+        marginTop: 0,
+      },
+      lg: {
+        marginTop: '5vh',
+        maxW: '100%',
+      },
+      xl: {
+        margin: '10vh auto 25px',
+      },
+    },
+    '.global-meta': {
+      marginBottom: '2vh',
+      fontSize: '12px',
+    },
+    '.global-meta, .global-tags': {
+      fontFamily: 'mono',
+      fontSize: '13px',
+      position: 'relative',
+      zIndex: 1,
+      width: '100%',
+    },
+    '.global-tags': {
+      '& a': {
+        display: 'inline-block',
+        margin: '10px 1.5% 0 0',
+      },
+    },
+    '.global-members-label': {
+      fontFamily: 'mono',
+      fontSize: '13px',
+      lineHeight: '1.4',
+      position: 'absolute',
+      top: '-30px',
+      left: '-1px',
+      color: 'black',
+      background: 'var(--color-details)',
+      textTransform: 'capitalize',
+    },
+    '.global-image': {
+      lineHeight: 0,
+      position: 'relative',
+      zIndex: 1,
+      float: 'right',
+      width: '125px',
+      height: '125px',
+      marginLeft: '7%',
+      marginBottom: '15px',
+      _after: {
+        background: 'orange',
+      },
+      '.is-hero &': {
+        right: '40px',
+        float: 'none',
+        flex: '0 0 350px',
+        order: 2,
+        width: '350px',
+        height: '100%',
+        margin: 0,
+      },
+      '& img': {
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+      },
+    },
+    '.custom-image': {
+      base: {
+        width: 450,
+      },
+      sm: {
+        display: 'none',
+      },
+    },
+    '.custom-container': {
+      flexDirection: 'column',
+      flexGrow: 1,
+    },
+    '.header-section': {
+      width: '100%',
+    },
+    '.header-wrap': {
+      minH: '60px',
+      marginTop: '20px',
+      marginBottom: '20px',
+      alignItems: 'center',
+      position: 'relative',
+    },
+    '.header-logo': {
+      base: {
+        flexBasis: '75%',
+      },
+      md: {
+        flexBasis: '50%',
+      },
+      xl: {
+        zIndex: 98,
+        top: 0,
+        width: '300px',
+        textAlign: 'center',
+        position: 'absolute',
+        left: 'calc(50% - 150px)',
+      },
+    },
+    '#mobile-nav': {
+      sm: {
+        display: 'flex',
+        justifyContent: 'flex-end',
+      },
+      xl: {
+        display: 'none',
+      },
+    },
+    '.header-nav': {
+      base: {
+        fontFamily: 'spartan',
+        position: 'relative',
+        zIndex: 99,
+        flex: '0 1 100%',
+      },
+      sm: {
+        flexBasis: '25%',
+        '& nav': {
+          display: 'none',
         },
-        ".global-wrap": {
-            height: "100%"
+      },
+      md: {
+        flexBasis: '50%',
+      },
+      xl: {
+        '& nav, & nav>ul+ul': {
+          display: 'flex',
+          alignItems: 'center',
+          flex: '0 0 auto',
         },
-        ".global-button": {
-            fontFamily: "two",
-            lineHeight: 1,
-            position: "relative",
-            zIndex: 0,
-            cursor: "pointer",
-            letterSpacing: "1px",
-            color: "var(--color-font-two)",
-            border: 0,
-            outline: 0,
-            _before: {
-                zIndex: -1,
-                background: "var(--color-details)",
-                position: "absolute",
-                top: 0,
-                right: 0,
-                left: 0,
-                bottom: 0,
-                content: "''"
-            },
-            _after: {
-                position: "absolute",
-                top: 0,
-                right: 0,
-                left: 0,
-                bottom: 0,
-                content: "''"
-            }
+        '& li, & a': {
+          fontSize: '14px',
+          display: 'inline-block',
         },
-        ".global-content": {
-            base: {
-                display: "flex",
-                position: "relative",
-                flexDirection: "column",
-                paddingRight: "6%",
-                paddingLeft: "6%",
-                height: "100%",
-                maxW: "unset"
-            },
-            md: {
-                padding: "0 55px"
-            }
+        '& a, & .signin a, & .signout a, & .signup': {
+          marginRight: '18px',
         },
-        ".global-main": {
-            width: "100%",
-            maxW: "1200px",
-            marginLeft: "auto",
-            marginRight: "auto"
+        '& .signup a': {
+          fontFamily: 'spartan',
+          fontSize: '12px',
+          marginRight: 0,
+          padding: '10px 12px 8px',
+          letterSpacing: '.5px',
+          lineHeight: '18px',
         },
-        ".global-underline": {
-            paddingBottom: ".2%",
-            transition: "background-size .6s ease-out",
-            background: "linear-gradient(var(--accent-color), var(--accent-color)) no-repeat left 123%/0 40%"
+      },
+    },
+    '.header-checkbox': {
+      display: 'none',
+      '&:checked~nav ul': {
+        position: 'relative',
+      },
+    },
+    '.header-toggle': {
+      display: 'block',
+      position: 'relative',
+      zIndex: '99',
+      overflow: 'visible',
+      width: '25px',
+      height: '25px',
+      margin: '0',
+      padding: '5px',
+      cursor: 'pointer',
+      opacity: '1',
+      border: '0',
+      outline: '0',
+      background: 'transparent',
+      '&>span': {
+        top: '50%',
+      },
+      '& span': {
+        display: 'block',
+        width: '100%',
+      },
+      '& .bar': {
+        position: 'absolute',
+        display: 'block',
+        width: '100%',
+        height: '3px',
+        content: "''",
+        transition:
+          'transform .3s cubic-bezier(.645, .045, .355, 1), top .3s cubic-bezier(.645, .045, .355, 1) .2s',
+        background: 'var(--color-two)',
+      },
+      '& .bar:nth-of-type(1)': {
+        top: '-10px',
+      },
+      '& .bar:nth-of-type(3)': {
+        top: '10px',
+      },
+    },
+    '.pinned-section': {
+      base: {
+        boxSizing: 'content-box',
+      },
+      sm: {
+        flexWrap: 'wrap',
+        marginBottom: '4vh',
+        border: 'var(--border) var(--color-three)',
+        padding: '35px 5% 0',
+      },
+      lg: {
+        padding: 0,
+        border: 'none',
+      },
+      xl: {
+        marginBottom: 0,
+        flexWrap: 'nowrap',
+      },
+    },
+    '.pinned-pages': {
+      base: {
+        boxSizing: 'content-box',
+        borderColor: 'var(--color-announcements)',
+      },
+      sm: {
+        maxW: '100%',
+      },
+      md: {
+        // marginTop: "5vh",
+      },
+      xl: {
+        flexBasis: '25%',
+      },
+    },
+    '.pinned-pages+.pinned-posts': {
+      xl: {
+        marginLeft: '35px',
+      },
+    },
+    '.pinned-posts': {
+      base: {
+        marginLeft: 0,
+        boxSizing: 'content-box',
+      },
+      sm: {
+        '.pinned-pages+&': {
+          marginTop: '15px',
         },
-        ".global-underline:hover": {
-            backgroundSize: "97% 40%"
+      },
+      xl: {
+        '.pinned-pages+&': {
+          marginTop: '10vh',
         },
-        ".global-special": {
-            base: {
-                paddingTop: "10px",
-                borderTop: "4px solid var(--color-details)",
-                flexGrow: 1,
-                position: "relative",
-                flexWrap: "wrap",
-            },
-            sm: {
-                margin: "10vh auto 25px",
-                marginTop: 0,
-            },
-            md: {
-                marginTop: 0
-            },
-            lg: {
-                marginTop: "5vh",
-                maxW: "100%"
-            },
-            xl: {
-                margin: "10vh auto 25px"
-            }
+        flexBasis: '75%',
+      },
+    },
+    '.loop-wrap': {
+      flexWrap: 'wrap',
+      marginBottom: 0,
+    },
+    '.item': {
+      base: {
+        maxW: '100%',
+        '&.is-hero': {
+          maxW: '100%',
+          marginTop: '10vh',
+          padding: '50px 0',
+          flexBasis: '100%',
         },
-        ".global-meta": {
-            marginBottom: "2vh",
-            fontSize: "12px"
+      },
+      sm: {
+        flexBasis: '100%',
+        marginTop: 0,
+        paddingTop: '0',
+        paddingBottom: '0',
+        marginBottom: '20px',
+        '&.is-hero.is-first': {
+          marginTop: 0,
         },
-        ".global-meta, .global-tags": {
-            fontFamily: "four",
-            fontSize: "13px",
-            position: "relative",
-            zIndex: 1,
-            width: "100%"
+      },
+      md: {
+        marginTop: '10vh',
+        maxW: '50%',
+        paddingTop: 0,
+        paddingBottom: 0,
+        flex: '1 0 50%',
+        marginBottom: 0,
+        '&.is-even': {
+          paddingRight: '2%',
+          paddingLeft: 0,
         },
-        ".global-tags": {
-            "& a": {
-                display: "inline-block",
-                margin: "10px 1.5% 0 0"
-            }
+        '&.is-odd': {
+          paddingRight: 0,
+          paddingLeft: '2%',
         },
-        ".global-members-label": {
-            fontFamily: "four",
-            fontSize: "13px",
-            lineHeight: "1.4",
-            position: "absolute",
-            top: "-30px",
-            left: "-1px",
-            color: "black",
-            background: "var(--color-details)",
-            textTransform: "capitalize"
+      },
+      lg: {
+        '&.is-hero.is-first': {
+          marginTop: '3vh',
         },
-        ".global-image": {
-            lineHeight: 0,
-            position: "relative",
-            zIndex: 1,
-            float: "right",
-            width: "125px",
-            height: "125px",
-            marginLeft: "7%",
-            marginBottom: "15px",
-            _after: {
-                background: "orange"
-            },
-            ".is-hero &": {
-                right: "40px",
-                float: "none",
-                flex: "0 0 350px",
-                order: 2,
-                width: "350px",
-                height: "100%",
-                margin: 0
-            },
-            "& img": {
-                width: "100%",
-                height: "100%",
-                objectFit: "cover"
-            }
+      },
+    },
+    '.item-container': {
+      base: {
+        boxSizing: 'border-box',
+        maxW: '100%',
+        position: 'relative',
+      },
+      sm: {
+        flexWrap: 'wrap',
+        '.post-header.is-hero &': {
+          alignItems: 'center',
         },
-        ".custom-image": {
-            base: {
-                width: 450
-            },
-            sm: {
-                display: "none"
-            }
+      },
+      md: {
+        flexWrap: 'nowrap',
+        '.post-header.is-hero.is-image': {
+          minHeight: '45vh',
         },
-        ".custom-container": {
-            flexDirection: "column",
-            flexGrow: 1
+        '.item.is-hero.is-image &': {
+          _before: {
+            zIndex: -2,
+            maxW: '275px',
+            width: '100%',
+            top: '-3.1vh',
+            right: 0,
+            bottom: '-4vh',
+            background: 'radial-gradient(var(--color-dots) 6%, transparent 0)',
+            position: 'absolute',
+            content: "''",
+            backgroundSize: '28px 28px',
+          },
+          _after: {
+            zIndex: -3,
+            position: 'absolute',
+            width: '100%',
+            maxW: '245px',
+            background: '#ff4a97',
+            top: '-4vh',
+            bottom: '3vh',
+            right: '26px',
+            content: "''",
+          },
         },
-        ".header-section": {
-            width: "100%"
+        '.item.is-odd &': {
+          borderLeft: 'var(--border) var(--color-three)',
         },
-        ".header-wrap": {
-            minH: "60px",
-            marginTop: "20px",
-            marginBottom: "20px",
-            alignItems: "center",
-            position: "relative"
+        '.item.is-even &': {
+          borderLeft: 'var(--border) var(--color-three)',
         },
-        ".header-logo": {
-            base: {
-                flexBasis: "75%"
-            },
-            md: {
-                flexBasis: "50%"
-            },
-            xl: {
-                zIndex: 98,
-                top: 0,
-                width: "300px",
-                textAlign: "center",
-                position: "absolute",
-                left: "calc(50% - 150px)"
-            }
+      },
+    },
+    '.item-title': {
+      base: {
+        fontSize: '24px',
+        width: '100%',
+        margin: '0 0 2vh -2px',
+        '.item.is-hero &': {
+          fontSize: '32px',
+          marginBottom: '0',
+          marginLeft: '-1px',
         },
-        "#mobile-nav": {
-            sm: {
-                display: "flex",
-                justifyContent: "flex-end",
-            },
-            xl: {
-                display: "none"
-            }
+      },
+      xl: {
+        fontSize: '30px',
+      },
+    },
+    '.item-excerpt': {
+      base: {
+        fontFamily: 'spartan',
+        fontSize: '13px',
+        lineHeight: '1.6',
+        width: '95%',
+        maxW: '400px',
+        marginTop: '0',
+        marginBottom: '0',
+        padding: '5px 0 10px',
+        '.item.is-hero &': {
+          lineHeight: 1.7,
+          columnCount: 1,
+          paddingTop: '15px',
+          paddingBottom: '5px',
         },
-        ".header-nav": {
-            base: {
-                fontFamily: "two",
-                position: "relative",
-                zIndex: 99,
-                flex: "0 1 100%",
-            },
-            sm: {
-                flexBasis: "25%",
-                "& nav": {
-                    display: "none"
-                }
-            },
-            md: {
-                flexBasis: "50%"
-            },
-            xl: {
-                "& nav, & nav>ul+ul": {
-                    display: "flex",
-                    alignItems: "center",
-                    flex: "0 0 auto"
-                },
-                "& li, & a": {
-                    fontSize: "14px",
-                    display: "inline-block"
-                },
-                "& a, & .signin a, & .signout a, & .signup": {
-                    marginRight: "18px",
-                },
-                "& .signup a": {
-                    fontFamily: "two",
-                    fontSize: "12px",
-                    marginRight: 0,
-                    padding: "10px 12px 8px",
-                    letterSpacing: ".5px",
-                    lineHeight: "18px"
-                }
-            }
+      },
+      lg: {
+        maxW: '500px',
+        paddingTop: '10px',
+        paddingBottom: '3vh',
+      },
+      xl: {
+        lineHeight: 1.7,
+        columnCount: '1',
+      },
+    },
+    '.item-content': {
+      base: {
+        width: '100%',
+      },
+      sm: {
+        padding: '10px 0 10px 5%',
+        paddingLeft: 0,
+      },
+      md: {
+        paddingLeft: '5%',
+      },
+    },
+    '.item-image': {
+      base: {
+        lineHeight: '0',
+        position: 'relative',
+        zIndex: 1,
+        float: 'right',
+        width: '95px',
+        height: '95px',
+        marginTop: '6px',
+        marginBottom: '15px',
+        marginLeft: '7%',
+        _after: {
+          position: 'absolute',
+          zIndex: -1,
+          content: "''",
+          pointerEvents: 'none',
+          top: '-6px',
+          right: '6px',
+          bottom: '6px',
+          left: '-6px',
         },
-        ".header-checkbox": {
-            display: "none",
-            "&:checked~nav ul": {
-                position: "relative"
-            }
+        'a&': {
+          display: 'block',
         },
-        ".header-toggle": {
-            display: "block",
-            position: "relative",
-            zIndex: "99",
-            overflow: "visible",
-            width: "25px",
-            height: "25px",
-            margin: "0",
-            padding: "5px",
-            cursor: "pointer",
-            opacity: "1",
-            border: "0",
-            outline: "0",
-            background: "transparent",
-            "&>span": {
-                top: "50%"
-            },
-            "& span": {
-                display: "block",
-                width: "100%"
-            },
-            "& .bar": {
-                position: "absolute",
-                display: "block",
-                width: "100%",
-                height: "3px",
-                content: "''",
-                transition: "transform .3s cubic-bezier(.645, .045, .355, 1), top .3s cubic-bezier(.645, .045, .355, 1) .2s",
-                background: "var(--color-two)"
-            },
-            "& .bar:nth-of-type(1)": {
-                top: "-10px"
-            },
-            "& .bar:nth-of-type(3)": {
-                top: "10px"
-            }
+        '.item.is-hero &': {
+          height: '100%',
+          margin: 0,
+          marginBottom: '20px',
+          flex: '0 0 350px',
+          right: 0,
+          _after: {
+            display: 'none',
+          },
         },
-        ".pinned-section": {
-            base: {
-                boxSizing: "content-box",
-            },
-            sm: {
-                flexWrap: "wrap",
-                marginBottom: "4vh",
-                border: "var(--border) var(--color-three)",
-                padding: "35px 5% 0",
-            },
-            lg: {
-                padding: 0,
-                border: "none"
-            },
-            xl: {
-                marginBottom: 0,
-                flexWrap: "nowrap"
-            }
-
+      },
+      sm: {
+        '.item.is-hero &': {
+          order: 0,
         },
-        ".pinned-pages": {
-            base: {
-                boxSizing: "content-box",
-                borderColor: "var(--color-announcements)"
-            },
-            sm: {
-                maxW: "100%"
-            },
-            md: {
-                // marginTop: "5vh",
-            },
-            xl: {
-                flexBasis: "25%",
-            }
+        '.item.is-hero & img': {
+          maxW: '240px',
         },
-        ".pinned-pages+.pinned-posts": {
-            xl: {
-                marginLeft: "35px"
-            }
+        '.item.is-hero.is-image &': {
+          _before: {
+            zIndex: -2,
+            right: 0,
+            bottom: '10px',
+            background: 'radial-gradient(var(--color-dots) 6%, transparent 0)',
+            position: 'absolute',
+            top: '-35px',
+            left: '35px',
+            display: 'block',
+            content: "''",
+            backgroundSize: '17px 17px',
+          },
+          _after: {
+            zIndex: -3,
+            maxWidth: '240px',
+            background: '#ff4a97',
+            position: 'absolute',
+            top: '-35px',
+            bottom: '40px',
+            left: '35px',
+            right: '6px',
+            display: 'block',
+            content: "''",
+            backgroundSize: '17px 17px',
+          },
         },
-        ".pinned-posts": {
-            base: {
-                marginLeft: 0,
-                boxSizing: "content-box"
-            },
-            sm: {
-                ".pinned-pages+&": {
-                    marginTop: "15px"
-                }
-            },
-            xl: {
-                ".pinned-pages+&": {
-                    marginTop: "10vh"
-                },
-                flexBasis: "75%"
-            }
+      },
+      md: {
+        '.item.is-hero &': {
+          order: 2,
+          width: '290px',
+          flexBasis: '290px',
         },
-        ".loop-wrap": {
-            flexWrap: "wrap",
-            marginBottom: 0
+        '.item.is-hero.is-image &': {
+          _before: {
+            display: 'none',
+          },
+          _after: {
+            display: 'none',
+          },
         },
-        ".item": {
-            base: {
-                maxW: "100%",
-                "&.is-hero": {
-                    maxW: "100%",
-                    marginTop: "10vh",
-                    padding: "50px 0",
-                    flexBasis: "100%"
-                },
-            },
-            sm: {
-                flexBasis: "100%",
-                marginTop: 0,
-                paddingTop: "0",
-                paddingBottom: "0",
-                marginBottom: "20px",
-                "&.is-hero.is-first": {
-                    marginTop: 0
-                }
-            },
-            md: {
-                marginTop: "10vh",
-                maxW: "50%",
-                paddingTop: 0,
-                paddingBottom: 0,
-                flex: "1 0 50%",
-                marginBottom: 0,
-                "&.is-even": {
-                    paddingRight: "2%",
-                    paddingLeft: 0
-                },
-                "&.is-odd": {
-                    paddingRight: 0,
-                    paddingLeft: "2%"
-                }
-            },
-            lg: {
-                "&.is-hero.is-first": {
-                    marginTop: "3vh"
-                }
-            }
+      },
+      lg: {
+        width: '95px',
+        height: '95px',
+        marginTop: '6px',
+        '.item.is-hero &': {
+          right: '0',
         },
-        ".item-container": {
-            base: {
-                boxSizing: "border-box",
-                maxW: "100%",
-                position: "relative",
-            },
-            sm: {
-                flexWrap: "wrap",
-                ".post-header.is-hero &": {
-                    alignItems: "center"
-                },
-            },
-            md: {
-                flexWrap: "nowrap",
-                ".post-header.is-hero.is-image": {
-                    minHeight: "45vh"
-                },
-                ".item.is-hero.is-image &": {
-                    _before: {
-                        zIndex: -2,
-                        maxW: "275px",
-                        width: "100%",
-                        top: "-3.1vh",
-                        right: 0,
-                        bottom: "-4vh",
-                        background: "radial-gradient(var(--color-dots) 6%, transparent 0)",
-                        position: "absolute",
-                        content: "''",
-                        backgroundSize: "28px 28px"
-                    },
-                    _after: {
-                        zIndex: -3,
-                        position: "absolute",
-                        width: "100%",
-                        maxW: "245px",
-                        background: "#ff4a97",
-                        top: "-4vh",
-                        bottom: "3vh",
-                        right: "26px",
-                        content: "''",
-
-                    }
-                },
-                ".item.is-odd &": {
-                    borderLeft: "var(--border) var(--color-three)"
-                },
-                ".item.is-even &": {
-                    borderLeft: "var(--border) var(--color-three)"
-                }
-            },
+      },
+      xl: {
+        right: '0',
+      },
+    },
+    '.is-odd': {
+      sm: {
+        '.item& .item-container': {
+          display: 'block',
+          borderLeft: 'none',
         },
-        ".item-title": {
-            base: {
-                fontSize: "24px",
-                width: "100%",
-                margin: "0 0 2vh -2px",
-                ".item.is-hero &": {
-                    fontSize: "32px",
-                    marginBottom: "0",
-                    marginLeft: "-1px",
-                }
-            },
-            xl: {
-                fontSize: "30px"
-            }
+      },
+    },
+    '.subscribe-section': {
+      base: {
+        marginTop: '8vh',
+      },
+    },
+    '.subscribe-wrap': {
+      base: {
+        marginTop: '8vh',
+        margin: '0 auto',
+        padding: '0 0 50px',
+        alignItems: 'center',
+      },
+      sm: {
+        flexWrap: 'wrap',
+      },
+      lg: {
+        flexWrap: 'nowrap',
+      },
+    },
+    '.subscribe-form': {
+      base: {
+        display: 'flex',
+        position: 'relative',
+        height: '50px',
+        boxSizing: 'content-box',
+      },
+      sm: {
+        flex: '0 0 auto',
+        width: '100%',
+        '& input': {
+          width: '20%',
+          height: 'unset',
+          paddingRight: '10px',
+          paddingLeft: '10px',
+          wordBreak: 'normal',
+          color: 'var(--color-body)',
+          background: 'var(--color-two)',
+          flex: '1 1 auto',
+          fontSize: '16px',
+          padding: '0 20px',
+          borderRadius: 0,
+          _focus: {
+            width: '270px',
+          },
         },
-        ".item-excerpt": {
-            base: {
-                fontFamily: "two",
-                fontSize: "13px",
-                lineHeight: "1.6",
-                width: "95%",
-                maxW: "400px",
-                marginTop: "0",
-                marginBottom: "0",
-                padding: "5px 0 10px",
-                ".item.is-hero &": {
-                    lineHeight: 1.7,
-                    columnCount: 1,
-                    paddingTop: "15px",
-                    paddingBottom: "5px"
-                }
-            },
-            lg: {
-                maxW: "500px",
-                paddingTop: "10px",
-                paddingBottom: "3vh"
-            },
-            xl: {
-                lineHeight: 1.7,
-                columnCount: "1"
-            }
+      },
+      md: {
+        height: '60px',
+        width: '70%',
+        '& input': {
+          width: '250px',
         },
-        ".item-content": {
-            base: {
-                width: "100%",
-            },
-            sm: {
-                padding: "10px 0 10px 5%",
-                paddingLeft: 0
-            },
-            md: {
-                paddingLeft: "5%"
-            }
+      },
+      lg: {
+        width: 'unset',
+        '& input': {
+          width: '250px',
         },
-        ".item-image": {
-            base: {
-                lineHeight: "0",
-                position: "relative",
-                zIndex: 1,
-                float: "right",
-                width: "95px",
-                height: "95px",
-                marginTop: "6px",
-                marginBottom: "15px",
-                marginLeft: "7%",
-                _after: {
-                    position: "absolute",
-                    zIndex: -1,
-                    content: "''",
-                    pointerEvents: 'none',
-                    top: "-6px",
-                    right: "6px",
-                    bottom: "6px",
-                    left: "-6px"
-                },
-                "a&": {
-                    display: "block"
-                },
-                ".item.is-hero &": {
-                    height: "100%",
-                    margin: 0,
-                    marginBottom: "20px",
-                    flex: "0 0 350px",
-                    right: 0,
-                    _after: {
-                        display: "none"
-                    }
-                },
-            },
-            sm: {
-                ".item.is-hero &": {
-                    order: 0
-                },
-                ".item.is-hero & img": {
-                    maxW: "240px"
-                },
-                ".item.is-hero.is-image &": {
-                    _before: {
-                        zIndex: -2,
-                        right: 0,
-                        bottom: "10px",
-                        background: "radial-gradient(var(--color-dots) 6%, transparent 0)",
-                        position: "absolute",
-                        top: "-35px",
-                        left: "35px",
-                        display: "block",
-                        content: "''",
-                        backgroundSize: "17px 17px"
-                    },
-                    _after: {
-                        zIndex: -3,
-                        maxWidth: "240px",
-                        background: "#ff4a97",
-                        position: "absolute",
-                        top: "-35px",
-                        bottom: "40px",
-                        left: "35px",
-                        right: "6px",
-                        display: "block",
-                        content: "''",
-                        backgroundSize: "17px 17px"
-                    }
-                }
-
-            },
-            md: {
-                ".item.is-hero &": {
-                    order: 2,
-                    width: "290px",
-                    flexBasis: "290px"
-                },
-                ".item.is-hero.is-image &": {
-                    _before: {
-                        display: "none"
-                    },
-                    _after: {
-                        display: "none"
-                    }
-                }
-            },
-            lg: {
-                width: "95px",
-                height: "95px",
-                marginTop: "6px",
-                ".item.is-hero &": {
-                    right: "0",
-                }
-            },
-            xl: {
-                right: "0"
-            }
+      },
+    },
+    '.subscribe-message': {
+      base: {
+        '& small': {
+          fontFamily: 'mono',
+          fontSize: '12px',
+          lineHeight: 1.1,
+          position: 'absolute',
+          right: 0,
+          bottom: '-38px',
+          left: '20px',
+          display: 'none',
+          width: '100%',
+          margin: 0,
+          padding: 0,
+          color: 'white',
         },
-        ".is-odd": {
-            sm: {
-                ".item& .item-container": {
-                    display: "block",
-                    borderLeft: "none"
-                }
-            }
+        '&.success .alert-success': {
+          display: 'block',
         },
-        ".subscribe-section": {
-            base: {
-                marginTop: "8vh"
-            }
+        '&.loading .alert-loading': {
+          display: 'block',
         },
-        ".subscribe-wrap": {
-            base: {
-                marginTop: "8vh",
-                margin: "0 auto",
-                padding: "0 0 50px",
-                alignItems: "center",
-            },
-            sm: {
-                flexWrap: "wrap"
-            },
-            lg: {
-                flexWrap: "nowrap",
-            }
-
+        '&.error .alert-error': {
+          display: 'block',
         },
-        ".subscribe-form": {
-            base: {
-                display: "flex",
-                position: "relative",
-                height: "50px",
-                boxSizing: "content-box",
-            },
-            sm: {
-                flex: "0 0 auto",
-                width: "100%",
-                "& input": {
-                    width: "20%",
-                    height: "unset",
-                    paddingRight: "10px",
-                    paddingLeft: "10px",
-                    wordBreak: "normal",
-                    color: "var(--color-body)",
-                    background: "var(--color-two)",
-                    flex: "1 1 auto",
-                    fontSize: "16px",
-                    padding: "0 20px",
-                    borderRadius: 0,
-                    _focus: {
-                        width: "270px",
-                    }
-                },
-                "& button": {
-                    height: "unset",
-                    paddingRight: "10px",
-                    paddingLeft: "10px",
-                    borderRadius: 0,
-                    background: "var(--color-details)",
-                    fontSize: "16px",
-                    padding: "0 20px",
-                    cursor: "pointer",
-                    color: "var(--color-font-two)",
-                    boxShadow: "none",
-                    flex: "0 0 auto",
-                }
-            },
-            md: {
-                height: "60px",
-                width: "70%",
-                "& input": {
-                    width: "250px"
-                }
-            },
-            lg: {
-                width: "unset",
-                "& input": {
-                    width: "250px"
-                }
-            }
+      },
+    },
+    '.pagination-section': {
+      base: {
+        paddingBottom: '1px',
+        textAlign: 'center',
+        boxSizing: 'content-box',
+      },
+      sm: {
+        marginTop: '5vh',
+        marginBottom: '9vh',
+      },
+      md: {
+        margin: '10vh auto 15vh',
+      },
+    },
+    '.global-footer': {
+      width: '100%',
+      maxW: '1200px',
+      marginRight: 'auto',
+      marginLeft: 'auto',
+      flexShrink: '0',
+    },
+    '.footer-section': {
+      paddingTop: '7vh',
+      paddingBottom: '6vh',
+      borderTop: '1px dashed #485b73',
+    },
+    '.footer-wrap': {
+      base: {
+        width: '100%',
+        margin: '0 auto',
+        alignItems: 'flex-start',
+        boxSizing: 'border-box',
+        flexWrap: 'wrap',
+      },
+      lg: {
+        flexWrap: 'nowrap',
+      },
+    },
+    '.footer-data': {
+      base: {
+        boxSizing: 'border-box',
+        paddingRight: '5%',
+        flex: '999 0 30%',
+      },
+      md: {
+        flexBasis: '100%',
+      },
+    },
+    '.footer-logo': {
+      marginBottom: '15px',
+      maxWidth: '350px',
+      '& .is-image img': {
+        maxW: '150px',
+        maxH: '45px',
+      },
+    },
+    '.footer-icons': {
+      base: {
+        marginTop: '30px',
+        marginBottom: '30px',
+        maxW: '340px',
+      },
+    },
+    '.footer-nav': {
+      base: {
+        flex: '1 0 auto',
+        flexWrap: 'nowrap',
+      },
+      sm: {
+        flexWrap: 'wrap',
+      },
+      md: {
+        maxW: '100%',
+        flexWrap: 'wrap',
+      },
+    },
+    '.footer-nav-column': {
+      base: {
+        width: '150px',
+        marginBottom: '30px',
+      },
+      sm: {
+        flex: '1 0 50%',
+      },
+      md: {
+        width: '100%',
+      },
+      '& ul': {
+        base: {
+          margin: 0,
+          paddingLeft: '15%',
         },
-        ".subscribe-message": {
-            base: {
-                "& small": {
-                    fontFamily: "four",
-                    fontSize: "12px",
-                    lineHeight: 1.1,
-                    position: "absolute",
-                    right: 0,
-                    bottom: "-38px",
-                    left: "20px",
-                    display: "none",
-                    width: "100%",
-                    margin: 0,
-                    padding: 0,
-                    color: "white"
-                },
-                "&.success .alert-success": {
-                    display: "block"
-                },
-                "&.loading .alert-loading": {
-                    display: "block"
-                },
-                "&.error .alert-error": {
-                    display: "block"
-                }
-            }
+        md: {
+          paddingRight: '20px',
+          paddingLeft: 0,
         },
-        ".pagination-section": {
-            base: {
-                paddingBottom: "1px",
-                textAlign: "center",
-                boxSizing: "content-box"
-            },
-            sm: {
-                marginTop: "5vh",
-                marginBottom: "9vh"
-            },
-            md: {
-                margin: "10vh auto 15vh"
-            }
+      },
+      '& li': {
+        base: {
+          fontFamily: 'spartan',
+          fontSize: '13px',
+          lineHeight: '2',
+          marginBottom: '16px',
+          listStyle: 'none',
         },
-        ".global-footer": {
-            width: "100%",
-            maxW: "1200px",
-            marginRight: "auto",
-            marginLeft: "auto",
-            flexShrink: "0"
+        lg: {
+          fontSize: '12px',
         },
-        ".footer-section": {
-            paddingTop: "7vh",
-            paddingBottom: "6vh",
-            borderTop: "1px dashed #485b73"
+      },
+    },
+    '.footer-copyright': {
+      base: {
+        display: 'block',
+        height: '25px',
+        marginTop: '30px',
+        padding: 0,
+        fontFamily: 'mono',
+        fontSize: '13px',
+      },
+    },
+    '.footer-description': {
+      margin: '0',
+      maxW: '350px',
+      fontFamily: 'mono',
+      fontSize: '13px',
+    },
+    '.post-share-section': {
+      '& a': {
+        display: 'flex',
+        width: '85px',
+        height: '64px',
+        pointerEvents: 'none',
+        border: 0,
+        justifyContent: 'center',
+        alignItems: 'center',
+      },
+      '& a:first-of-type': {
+        paddingLeft: '10px',
+        borderLeft: 'var(--border) var(--color-three)',
+      },
+      '& a:last-of-type': {
+        paddingRight: '10px',
+        borderRight: 'var(--border) var(--color-three)',
+      },
+    },
+    body: {
+      bg: '#182029',
+      lineHeight: '1.5',
+      wordWrap: 'break-word',
+      wordBreak: 'break-word',
+      fontSize: '19px',
+      color: '#f7f9f9',
+    },
+    hr: {
+      marginTop: '6vmin',
+      width: '100%',
+      position: 'relative',
+      margin: '2.5em 0 3.5em',
+      padding: '0',
+      height: '1px',
+      border: '0',
+      borderTop: '1px solid #f0f0f0',
+    },
+    article: {
+      base: {
+        '.global-special &': {
+          boxSizing: 'border-box',
         },
-        ".footer-wrap": {
-            base: {
-                width: "100%",
-                margin: "0 auto",
-                alignItems: "flex-start",
-                boxSizing: "border-box",
-                flexWrap: "wrap"
-            },
-            lg: {
-                flexWrap: "nowrap"
-            }
+      },
+      sm: {
+        '.global-special &': {
+          padding: '10px 25px 10px',
+          paddingLeft: 0,
         },
-        ".footer-data": {
-            base: {
-                boxSizing: "border-box",
-                paddingRight: "5%",
-                flex: "999 0 30%"
-            },
-            md: {
-                flexBasis: "100%"
-            }
+      },
+      md: {
+        '.global-special &': {
+          padding: '10px 25px 10px',
+          paddingLeft: 0,
         },
-        ".footer-logo": {
-            marginBottom: "15px",
-            maxWidth: "350px",
-            "& .is-image img": {
-                maxW: "150px",
-                maxH: "45px"
-            }
+      },
+      lg: {
+        '.global-special  &': {
+          flexBasis: '100%',
+          padding: '10px 25px 10px',
         },
-        ".footer-icons": {
-            base: {
-                marginTop: "30px",
-                marginBottom: "30px",
-                maxW: "340px"
-            }
+        '.global-special &:not(:first-of-type):not(:last-of-type), .global-special &:last-of-type':
+          {
+            borderLeft: 'var(--border) var(--color-three)',
+          },
+        '.global-special &:first-of-type:last-of-type': {
+          borderLeft: 'none',
         },
-        ".footer-nav": {
-            base: {
-                flex: "1 0 auto",
-                flexWrap: "nowrap"
-            },
-            sm: {
-                flexWrap: "wrap"
-            },
-            md: {
-                maxW: "100%",
-                flexWrap: "wrap"
-            }
+        '.global-special &:first-of-type': {
+          paddingLeft: 0,
         },
-        ".footer-nav-column": {
-            base: {
-                width: "150px",
-                marginBottom: "30px"
-            },
-            sm: {
-                flex: "1 0 50%"
-            },
-            md: {
-                width: "100%"
-            },
-            "& ul": {
-                base: {
-                    margin: 0,
-                    paddingLeft: "15%"
-                },
-                md: {
-                    paddingRight: "20px",
-                    paddingLeft: 0
-                }
-            },
-            "& li": {
-                base: {
-                    fontFamily: "two",
-                    fontSize: "13px",
-                    lineHeight: "2",
-                    marginBottom: "16px",
-                    listStyle: "none"
-                },
-                lg: {
-                    fontSize: "12px"
-                }
-            }
+        '.global-special &': {
+          flex: '1 0 25%',
         },
-        ".footer-copyright": {
-            base: {
-                display: "block",
-                height: "25px",
-                marginTop: "30px",
-                padding: 0,
-                fontFamily: "four",
-                fontSize: "13px",
-            }
+      },
+      xl: {
+        '.global-special &': {
+          padding: '10px 25px',
         },
-        ".footer-description": {
-            margin: "0",
-            maxW: "350px",
-            fontFamily: "four",
-            fontSize: "13px"
+      },
+    },
+    p: {
+      fontSize: '19px',
+      fontWeight: '400',
+      lineHeight: '1.75',
+      position: 'relative',
+      fontFamily: 'mulish',
+      marginRight: '0',
+      marginLeft: '0',
+      marginBottom: '40px',
+    },
+    blockquote: {
+      fontSize: '30px',
+      position: 'relative',
+      width: '100%',
+      paddingLeft: '55px',
+      lineHeight: '1.5',
+      boxSizing: 'border-box',
+      fontFamily: 'spartan',
+      my: '75px',
+      '&::before': {
+        fontFamily: 'spartan',
+        position: 'absolute',
+        content: "'\"'",
+      },
+    },
+    ul: {
+      paddingLeft: '15px',
+      listStyle: 'disc outside',
+      marginRight: '0',
+      marginLeft: '15px',
+      marginBottom: '40px',
+      marginTop: '0',
+      '.header-nav nav &': {
+        zIndex: 1,
+        margin: 0,
+        padding: 0,
+        listStyle: 'none',
+        wordBreak: 'normal',
+      },
+      '.header-nav nav>&': {
+        flexGrow: 1,
+      },
+    },
+    li: {
+      textAlign: '-webkit-match-parent',
+    },
+    'h1,h2,h3,h4,h5,h6': {
+      fontFamily: 'spartan',
+    },
+    h1: {
+      fontSize: '55px',
+      marginTop: '60px',
+    },
+    h2: {
+      fontSize: '41px',
+      marginTop: '55px',
+      lineHeight: '1.4',
+      marginBottom: '20px',
+      marginLeft: '-1px',
+      '.global-special &': {
+        fontFamily: 'mono',
+        fontSize: '13px',
+        lineHeight: '1.4',
+        position: 'absolute',
+        zIndex: 1,
+        top: 0,
+        left: 0,
+        display: 'inline-block',
+        margin: 0,
+        transform: 'translateY(-100%)',
+        letterSpacing: 0,
+        color: 'var(--color-font-two)',
+      },
+      '.global-special & span': {
+        background: 'var(--color-details)',
+      },
+      '.pinned-pages & span': {
+        background: 'var(--color-announcements)',
+      },
+      '&.item-title': {
+        fontSize: '24px',
+        marginLeft: 0,
+      },
+    },
+    h3: {
+      base: {
+        fontSize: '31px',
+        '.global-special &': {
+          fontSize: '20px',
         },
-        ".post-share-section": {
-            "& a": {
-                display: "flex",
-                width: "85px",
-                height: "64px",
-                pointerEvents: "none",
-                border: 0,
-                justifyContent: "center",
-                alignItems: "center"
-            },
-            "& a:first-of-type": {
-                paddingLeft: "10px",
-                borderLeft: "var(--border) var(--color-three)"
-            },
-            "& a:last-of-type": {
-                paddingRight: "10px",
-                borderRight: "var(--border) var(--color-three)"
-            }
+        '.subscribe-wrap &': {
+          lineHeight: 1.1,
+          boxSizing: 'border-box',
+          minW: '280px',
+          margin: 0,
+          padding: '25px 5% 25px 0',
+          flex: '1 1 50%',
         },
-        body: {
-            bg: "#182029",
-            lineHeight: "1.5",
-            wordWrap: "break-word",
-            wordBreak: "break-word",
-            fontSize: "19px",
-            color: "#f7f9f9"
+        '.global-special &+.global-meta': {
+          marginBottom: 0,
         },
-        hr: {
-            marginTop: "6vmin",
-            width: "100%",
-            position: "relative",
-            margin: "2.5em 0 3.5em",
-            padding: "0",
-            height: "1px",
-            border: "0",
-            borderTop: "1px solid #f0f0f0"
+      },
+      sm: {
+        '.global-special &': {
+          fontSize: '15px',
         },
-        article: {
-            base: {
-                ".global-special &": {
-                    boxSizing: "border-box",
-                },
-            },
-            sm: {
-                ".global-special &": {
-                    padding: "10px 25px 10px",
-                    paddingLeft: 0
-                }
-            },
-            md: {
-                ".global-special &": {
-                    padding: "10px 25px 10px",
-                    paddingLeft: 0
-                }
-            },
-            lg: {
-                ".global-special  &": {
-                    flexBasis: "100%",
-                    padding: "10px 25px 10px"
-                },
-                ".global-special &:not(:first-of-type):not(:last-of-type), .global-special &:last-of-type": {
-                    borderLeft: "var(--border) var(--color-three)"
-                },
-                ".global-special &:first-of-type:last-of-type": {
-                    borderLeft: "none",
-
-                },
-                ".global-special &:first-of-type": {
-                    paddingLeft: 0
-                },
-                ".global-special &": {
-                    flex: "1 0 25%",
-                },
-
-            },
-            xl: {
-                ".global-special &": {
-                    padding: "10px 25px"
-                }
-            }
+        '.subscribe-wrap &': {
+          fontSize: '35px',
         },
-        p: {
-            fontSize: "19px",
-            fontWeight: "400",
-            lineHeight: "1.75",
-            position: "relative",
-            fontFamily: "three",
-            marginRight: "0",
-            marginLeft: "0",
-            marginBottom: "40px"
+      },
+      lg: {
+        marginTop: '45px',
+        '.global-special &': {
+          marginTop: 0,
+          marginBottom: '1vh',
         },
-        blockquote: {
-            fontSize: "30px",
-            position: "relative",
-            width: "100%",
-            paddingLeft: "55px",
-            lineHeight: "1.5",
-            boxSizing: "border-box",
-            fontFamily: "two",
-            my: "75px",
-            "&::before": {
-                fontFamily: "two",
-                position: "absolute",
-                content: "'\"'",
-            }
+        '.subscribe-wrap &': {
+          fontSize: '35px',
         },
-        ul: {
-            paddingLeft: "15px",
-            listStyle: "disc outside",
-            marginRight: "0",
-            marginLeft: "15px",
-            marginBottom: "40px",
-            marginTop: "0",
-            ".header-nav nav &": {
-                zIndex: 1,
-                margin: 0,
-                padding: 0,
-                listStyle: "none",
-                wordBreak: "normal"
-            },
-            ".header-nav nav>&": {
-                flexGrow: 1
-            }
-        },
-        li: {
-            textAlign: "-webkit-match-parent"
-        },
-        "h1,h2,h3,h4,h5,h6": {
-            fontFamily: "one",
-        },
-        h1: {
-            fontSize: "55px",
-            marginTop: "60px"
-        },
-        h2: {
-            fontSize: "41px",
-            marginTop: "55px",
-            lineHeight: "1.4",
-            marginBottom: "20px",
-            marginLeft: "-1px",
-            ".global-special &": {
-                fontFamily: "four",
-                fontSize: "13px",
-                lineHeight: "1.4",
-                position: "absolute",
-                zIndex: 1,
-                top: 0,
-                left: 0,
-                display: "inline-block",
-                margin: 0,
-                transform: "translateY(-100%)",
-                letterSpacing: 0,
-                color: "var(--color-font-two)"
-            },
-            ".global-special & span": {
-                background: "var(--color-details)"
-            },
-            ".pinned-pages & span": {
-                background: "var(--color-announcements)",
-            },
-            "&.item-title": {
-                fontSize: "24px",
-                marginLeft: 0,
-            }
-        },
-        h3: {
-            base: {
-                fontSize: "31px",
-                ".global-special &": {
-                    fontSize: "20px",
-                },
-                ".subscribe-wrap &": {
-                    lineHeight: 1.1,
-                    boxSizing: "border-box",
-                    minW: "280px",
-                    margin: 0,
-                    padding: "25px 5% 25px 0",
-                    flex: "1 1 50%"
-                },
-                ".global-special &+.global-meta": {
-                    marginBottom: 0
-                }
-            },
-            sm: {
-                ".global-special &": {
-                    fontSize: "15px"
-                },
-                ".subscribe-wrap &": {
-                    fontSize: "35px"
-                }
-            },
-            lg: {
-                marginTop: "45px",
-                ".global-special &": {
-                    marginTop: 0,
-                    marginBottom: "1vh"
-                },
-                ".subscribe-wrap &": {
-                    fontSize: "35px"
-                }
-            }
-        },
-        h4: {
-            fontSize: "24px",
-            marginTop: "40px"
-        },
-        h5: {
-            fontSize: "20px",
-            marginTop: "40px"
-        },
-        h6: {
-            fontSize: "11px",
-            marginTop: "45px",
-            letterSpacing: "2px",
-            textTransform: "uppercase"
-        }
-    }
-}
+      },
+    },
+    h4: {
+      fontSize: '24px',
+      marginTop: '40px',
+    },
+    h5: {
+      fontSize: '20px',
+      marginTop: '40px',
+    },
+    h6: {
+      fontSize: '11px',
+      marginTop: '45px',
+      letterSpacing: '2px',
+      textTransform: 'uppercase',
+    },
+  },
+};


### PR DESCRIPTION
fixes #46

This PR does a few things.

### 1. Fix mobile navigation

Updated the mobile navigation so it no longer looks broken on mobile. I also opted for a `<Drawer />` component instead of a `<Menu />` so that it doesn't cause the UI to "jump" on mobile and so we don't get weird "focus" state of the active menu item.

<img width="1422" alt="CleanShot 2021-09-05 at 14 13 16@2x" src="https://user-images.githubusercontent.com/555044/132141662-bddf2283-cd6d-46cb-978a-e93e20a5c0f2.png">

![CleanShot 2021-09-05 at 14 12 51](https://user-images.githubusercontent.com/555044/132141665-2afd77d4-c114-4233-a615-b084a3186f67.gif)


### 2. Rename the fonts in the chakra theme
I renamed these fonts to have more discernible names than "one", "two" etc... and added them to the chakra theme so that they can be referenced from component props.

### 3. Added some color variables to the chakra theme.

Moved some of the color variables to the chakra theme so that we can use them in component props without css vars. Also gave them some more friendly names that relate to visual appearance of the color.

### 4. Setup default button styles
Added a `solid` button style to chakra theme so buttons will default to the solid red style.



