### PR TITLE
Prevent storing "null" as ensName

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -184,7 +184,7 @@ function ConnectionButton(props: ButtonProps) {
     if (ensName) {
       return ensName;
     }
-    return `${walletAddress.substr(0, 3)}..${walletAddress.substr(-3)}`;
+    return `${walletAddress.substr(0, 4)}..${walletAddress.substr(-3)}`;
   };
 
   return (

--- a/lib/web3.ts
+++ b/lib/web3.ts
@@ -71,9 +71,9 @@ export function getENSName(): string | null {
   if (typeof window === 'undefined') {
     return null;
   }
-  const connected = window.localStorage.getItem('ensName');
-  if (connected !== null && connected.length) {
-    return connected;
+  const name = window.localStorage.getItem('ensName');
+  if (name !== null && name.length && name !== 'null') {
+    return name;
   }
   return null;
 }
@@ -129,8 +129,12 @@ export async function connectWallet(): Promise<false | string> {
       const walletAddress = accounts[0];
       const name = await loadENSName(walletAddress);
       // Saving wallet to localstorage
-      localStorage.setItem('wallet', walletAddress);
-      localStorage.setItem('ensName', name);
+      if (walletAddress) {
+        localStorage.setItem('wallet', walletAddress);
+      }
+      if (name) {
+        localStorage.setItem('ensName', name);
+      }
       console.log('Connected account is:', walletAddress, name);
       return accounts[0];
     } catch (e) {


### PR DESCRIPTION
fixes #69 

This was caused by the web3 code storing null values for ens names as the string value "null", thus the UI code was seeing "null" as an ensName and rendering it.