### PR TITLE
Fix wallet name showing as null

### DIFF
--- a/lib/web3.ts
+++ b/lib/web3.ts
@@ -72,7 +72,7 @@ export function getENSName(): string | null {
     return null;
   }
   const connected = window.localStorage.getItem('ensName');
-  if (connected !== null && connected.length) {
+  if (connected !== null && connected.length && connected !== 'null') {
     return connected;
   }
   return null;


### PR DESCRIPTION
closes #69 

ensName variable was storing null as a string causing the issue