### PR TITLE
add two ways of slide-up animation

### DIFF
--- a/components/MainArticle.tsx
+++ b/components/MainArticle.tsx
@@ -3,6 +3,9 @@ import { PostOrPage, Tag } from '@tryghost/content-api';
 import { urlForPost } from '../lib/posts';
 import { urlForTag } from '../lib/tags';
 import Link from './Link';
+import { MotionBox } from './MotionBox';
+
+
 
 type MainArticleProps = {
   post: PostOrPage;
@@ -11,56 +14,64 @@ type MainArticleProps = {
 
 const MainArticle = ({ post, index }: MainArticleProps) => {
   return (
-    <Box as="article" className="item is-hero is-first is-image">
-      <Flex
-        className="item-container global-color"
-        flexDirection={{ sm: 'column', md: 'column-reverse', lg: 'row' }}
-      >
-        <Link
-          className="item-image global-image global-color"
-          style={{ boxShadow: 'none' }}
-          href={urlForPost(post)}>
-          <Image
-            loading="lazy"
-            objectFit="cover"
-            src={post.feature_image!}
-            alt={post.title}
-          />
-        </Link>
-        <Box
-          className="item-content"
-          width="100%"
-          padding="0"
-          paddingRight="5%"
-          willChange="transfrom">
-          <Text className="global-meta">
-            A long time ago by {post.primary_author!.name} - {post.reading_time}{' '}
-            minutes
-          </Text>
-          <Heading as="h2" className="item is-hero item-title">
-            <Link
-              className="global-underline"
-              style={{ boxShadow: 'none' }}
-              textDecoration="none"
-              href={urlForPost(post)}>
-              {post.title}
-            </Link>
-          </Heading>
-          <Text className="is-hero item-excerpt">{post.excerpt}</Text>
-          <Box className="global-tags">
-            {post.tags!.map((tag: Tag) => (
+
+    <MotionBox 
+    animate={{ y: -60 }}
+      transition={{ ease: "easeIn", delay: 0.5 }}
+    >
+
+      <Box as="article" className="item is-hero is-first is-image ">
+        <Flex
+          className="item-container global-color"
+          flexDirection={{ sm: 'column', md: 'column-reverse', lg: 'row' }}
+        >
+          <Link
+            className="item-image global-image global-color"
+            style={{ boxShadow: 'none' }}
+            href={urlForPost(post)}>
+            <Image
+              loading="lazy"
+              objectFit="cover"
+              src={post.feature_image!}
+              alt={post.title}
+            />
+          </Link>
+          <Box
+            className="item-content"
+            width="100%"
+            padding="0"
+            paddingRight="5%"
+            willChange="transfrom">
+            <Text className="global-meta">
+              A long time ago by {post.primary_author!.name} - {post.reading_time}{' '}
+              minutes
+            </Text>
+            <Heading as="h2" className="item is-hero item-title">
               <Link
-                key={tag.id}
-                textTransform="lowercase"
+                className="global-underline"
+                style={{ boxShadow: 'none' }}
                 textDecoration="none"
-                href={urlForTag(tag)}>
-                #{tag.name}
+                href={urlForPost(post)}>
+                {post.title}
               </Link>
-            ))}
+            </Heading>
+            <Text className="is-hero item-excerpt">{post.excerpt}</Text>
+            <Box className="global-tags">
+              {post.tags!.map((tag: Tag) => (
+                <Link
+                  key={tag.id}
+                  textTransform="lowercase"
+                  textDecoration="none"
+                  href={urlForTag(tag)}>
+                  #{tag.name}
+                </Link>
+              ))}
+            </Box>
           </Box>
-        </Box>
-      </Flex>
-    </Box>
+        </Flex>
+      </Box>
+    </MotionBox>
+
   );
 };
 

--- a/components/MotionBox.tsx
+++ b/components/MotionBox.tsx
@@ -1,0 +1,22 @@
+import { motion, MotionProps } from "framer-motion";
+import {
+    forwardRef,
+    ChakraProps,
+    chakra,
+    ComponentWithAs
+  } from '@chakra-ui/react';
+export type MotionBoxProps = Omit<
+  ChakraProps,
+  keyof MotionProps
+> &
+  MotionProps & {
+    as?: React.ElementType;
+  };
+
+  
+
+export const MotionBox = motion(
+  forwardRef<ChakraProps, "div">((props, ref) => {
+    return <chakra.div ref={ref} {...props} />;
+  })
+) as ComponentWithAs<"div", MotionBoxProps>;

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -13,6 +13,7 @@ import ShareLinks from './ShareLinks';
 import RelatedPosts from './RelatedPosts';
 import NextPrevSection from './NextPrevPost';
 import SubscribeSection from './SubscribeSection';
+import { MotionBox } from './MotionBox';
 
 export interface PostOrPageProps {
   cmsData: {
@@ -35,8 +36,11 @@ export default function Post({ cmsData }: PostOrPageProps): JSX.Element {
         <meta name="description" content={post.excerpt} />
       </Head>
       <chakra.article maxW="1200px" mx="auto">
-        <Box
-          className="post-header item is-hero is-image"
+        <MotionBox 
+    //      animate={{y:-40}}
+    //  transition={{ease: "easeIn" ,delay: 0.5 }}
+        > <Box
+          className="post-header item is-hero is-image slide-up"
           flexBasis="100%"
           maxWidth="100%"
           padding="50px 0"
@@ -102,7 +106,8 @@ export default function Post({ cmsData }: PostOrPageProps): JSX.Element {
               </Box>
             </Box>
           </Flex>
-        </Box>
+        </Box> </MotionBox >
+
         <Box
           className="postContent"
           dangerouslySetInnerHTML={{ __html: post.html! }}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,6 +10,7 @@ import type { AppProps } from 'next/app';
 import { ChakraProvider } from '@chakra-ui/react';
 import theme from '../theme';
 import '../styles/Mobile.css';
+import '../styles/globals.css';
 import Head from 'next/head';
 import { Web3Provider } from '../contexts/Web3Context';
 import Layout from '../components/Layout';

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,3 +19,16 @@ a {
   background: blue;
   padding: 16px;
 }
+
+@keyframes SlideUp {
+  0% {
+    transform: translateY(20%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+.slide-up {
+  animation: SlideUp .5s ease;
+}


### PR DESCRIPTION
 Fix Issue #104 
 Got two ways of adding this slide-up animation when rendering posts. Same effect.
- One way is adding a `slide-up` css class in global.css file. 
- One way is using chakra ui+framer to create a MotionBox component and wrap a post component in it. 
I add these two in this branch.